### PR TITLE
Update git blame command to use 'origin/' prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ to see how the Unix pipe functionality evolved over the years.
 ### Marvel at the oldest code in a modern Unix system
 Run
 ```
-git blame -C -C -M -M FreeBSD-releng/15.0 -- lib/libc/gen/timezone.c | grep Ritchie
+git blame -C -C -M -M origin/FreeBSD-releng/15.0 -- lib/libc/gen/timezone.c | grep Ritchie
 ```
 to see code written by Dennis Ritchie in 1979 still part of the 2025
 FreeBSD 15.0 C library.


### PR DESCRIPTION
This is needed for ref disambiguation, otherwise it may bark as follows; checking different versions of git, to be sure:

```
% git blame -C -C -M -M FreeBSD-releng/15.0 -- lib/libc/gen/timezone.c | grep Ritchie

fatal: bad revision 'FreeBSD-releng/15.0'
% git --version
git version 2.52.0
% which git
/opt/homebrew/bin/git
% /usr/bin/git blame -C -C -M -M FreeBSD-releng/15.0 -- lib/libc/gen/timezone.c | grep Ritchie

fatal: bad revision 'FreeBSD-releng/15.0'
% /usr/bin/git --version
git version 2.39.3 (Apple Git-145)
```
