### PR TITLE
Attribute tp.c to Melvin Ferentz

### DIFF
--- a/src/author-path/Research-V7
+++ b/src/author-path/Research-V7
@@ -37,6 +37,9 @@ usr/src/cmd/deroff\.c		llc
 usr/man/man1/tar.1		ken
 usr/src/cmd/tar/.*		ken
 
+# From header comment in tp.h
+usr/src/cmd/tp/.*		x-mf
+
 # 1. Owner listed in V1/man
 # http://minnie.tuhs.org/cgi-bin/utree.pl?file=V1/man/man1
 

--- a/src/bell.au
+++ b/src/bell.au
@@ -32,3 +32,6 @@ srb:S. R. Bourne
 tad:Ted Dolotta
 tbl:Tom London
 x-hg:Herb Gellis
+
+# Actually at Brooklyn College of CUNY
+x-mf:Melvin Ferentz


### PR DESCRIPTION
The header comment in V7 [tp.h](https://github.com/dspinellis/unix-history-repo/blob/e005199fcbe9d3676ddf72c1d31dd42f7216ad8a/usr/src/cmd/tp/tp.h#L1-L7) credits Melvin Ferentz for the rewrite from assembly to C. He ran UNIX News and the UNIX Users' Group, which became ;login: and USENIX. I presume tp.c was first distributed via USENIX and, indeed, a later version is in (at least) the 1980 [USENIX tape](https://www.tuhs.org/Archive/Applications/Shoppa_Tapes/).

```c
/*      c-version of tp?.s
 *
 *      M. Ferentz
 *      August 1976
 *
 *      revised July 1977 BTL
 */
```

I do now know who would have revised it at BTL.

I did not know a good place to put his author information, so chose bell.au. His email is incorrect.

I have not tested this.